### PR TITLE
Update: Gas Stations Blips

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -109,7 +109,7 @@ if Config.ShowNearestGasStationOnly then
 		end
 	end)
 	
-elseif Config.ShowAllGasStations then
+else
 	CreateThread(function()
 		for _, gasStationCoords in pairs(Config.GasStationsBlips) do
 			CreateBlip(gasStationCoords)

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -1,6 +1,5 @@
 Config = {}
-Config.ShowNearestGasStationOnly = true -- show nearest gas stations when close enough
-Config.ShowAllGasStations = true -- show all gas stations around map
+Config.ShowNearestGasStationOnly = true -- show nearest gas stations when close enough. If set to false, will show all blips for all gas stations.
 Config.LeaveEngineRunning = true -- when set to true vehicle engine will run upon exiting vehicle
 Config.VehicleBlowUp = true -- when set to true vehicle has a chance to blow up if engine is left running
 Config.BlowUpChance = 5 -- percentage for chance of engine explosion


### PR DESCRIPTION
No need for two config options for the blips when an "else" exists in the if statement.
One singular config option to set to true or false.