### PR TITLE
Turn Ped to Vehicle | Typo

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -257,7 +257,7 @@ RegisterNetEvent('ps-fuel:client:SendMenuToServer', function()
 	if HasPedGotWeapon(ped, 883325847) then
 		if GetAmmoInPedWeapon(ped, 883325847) ~= 0 then
 			if CurFuel < 95 then
-				TriggerServerEvent('ps-fuel:server:OpenMenu', 0, inGasStatio, true)
+				TriggerServerEvent('ps-fuel:server:OpenMenu', 0, inGasStation, true)
 			else
 				QBCore.Functions.Notify(Lang:t("notify.vehicle_full"), "error")
 			end

--- a/client/utils.lua
+++ b/client/utils.lua
@@ -74,6 +74,10 @@ function isCloseVeh()
     vehicle = getVehicleInDirection(coordA, coordB)
     if DoesEntityExist(vehicle) and NetworkHasControlOfEntity(vehicle) then
         return true
+	else
+		TaskTurnPedToFaceEntity(ped, closestVehicle, 1000)
+		Wait(1000)
+		return true
     end
     return false
 end


### PR DESCRIPTION
This is to change the PR for the typo and turning ped to the vehicle and then returning true for the script to run and fuel the vehicle.